### PR TITLE
Fixes for banner option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,13 +17,13 @@ const isFnOrString = ( v ) => {
 };
 
 function babili( options = {} ) {
-	let _banner;
+	let rollupBanner;
 
 	return {
 		name: 'babili',
 
 		options( { banner } ) {
-			_banner = banner;
+			rollupBanner = banner;
 		},
 
 		transformBundle( bundle ) {
@@ -33,8 +33,8 @@ function babili( options = {} ) {
 				comments: typeof options.comments !== 'undefined' ? Boolean( options.comments ) : true
 			};
 
-			if ( isFnOrString( options.banner ) || isFnOrString ( _banner ) ) {
-				let banner = options.banner || _banner;
+			if ( isFnOrString( options.banner ) || isFnOrString ( rollupBanner ) ) {
+				let banner = options.banner || rollupBanner;
 				banner = isFn ( banner ) ? banner() : banner;
 				const bannerContent = getCommentContent( banner );
 				let isAlreadyInserted = false;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,17 @@ import bannerPlugin from '@comandeer/babel-plugin-banner';
 import { getCommentContent } from '@comandeer/babel-plugin-banner/utils';
 import { transform } from 'babel-core';
 
+// NOTE: lodash or something else more precise can be an option here
+const isString = ( v ) => {
+	return v != null && typeof v === 'string';
+};
+const isFn = ( v ) => {
+	return v != null && typeof v === 'function';
+};
+const isFnOrString = ( v ) => {
+	return isString( v ) || isFn( v );
+};
+
 function babili( options = {} ) {
 	let _banner;
 
@@ -22,8 +33,9 @@ function babili( options = {} ) {
 				comments: typeof options.comments !== 'undefined' ? Boolean( options.comments ) : true
 			};
 
-			if ( typeof options.banner === 'string' || typeof _banner === 'string' ) {
-				const banner = options.banner || _banner;
+			if ( isFnOrString( options.banner ) || isFnOrString ( _banner ) ) {
+				let banner = options.banner || _banner;
+				banner = isFn ( banner ) ? banner() : banner;
 				const bannerContent = getCommentContent( banner );
 				let isAlreadyInserted = false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,18 +6,24 @@ import { getCommentContent } from '@comandeer/babel-plugin-banner/utils';
 import { transform } from 'babel-core';
 
 function babili( options = {} ) {
+	let _banner;
+
 	return {
 		name: 'babili',
 
-		transformBundle( bundle, rollupOptions ) {
+		options( { banner } ) {
+			_banner = banner;
+		},
+
+		transformBundle( bundle ) {
 			const babelConf = {
 				presets: [ [ babiliPreset, options ] ],
 				sourceMaps: typeof options.sourceMap !== 'undefined' ? Boolean( options.sourceMap ) : true,
 				comments: typeof options.comments !== 'undefined' ? Boolean( options.comments ) : true
 			};
 
-			if ( typeof options.banner === 'string' || typeof rollupOptions.banner === 'string' ) {
-				const banner = options.banner || rollupOptions.banner;
+			if ( typeof options.banner === 'string' || typeof _banner === 'string' ) {
+				const banner = options.banner || _banner;
 				const bannerContent = getCommentContent( banner );
 				let isAlreadyInserted = false;
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -93,6 +93,20 @@ describe( 'rollup-plugin-babili', () => {
 		} );
 	} );
 
+	it ( 'adds banner inherited from root configuration', () => {
+		// while you can ask: WTF? banner is not an option for an rollup
+		// function, this is how options from config file are passed
+		return rollup( {
+			entry: 'fixtures/index.js',
+			banner: '/* hublabubla */',
+			plugins: [ plugin() ],
+		} ).then( ( bundle ) => {
+			const result = bundle.generate();
+
+			expect ( result.code ).to.match( /^\/\* hublabubla \*\// );
+		} );
+	} );
+
 	it( 'prefers banner from own options over one inherited from bundle.generate', () => {
 		return rollup( {
 			entry: 'fixtures/index.js',
@@ -105,7 +119,7 @@ describe( 'rollup-plugin-babili', () => {
 			} );
 
 			expect( result.code ).to.match( /^\/\* ROLLUP RULEZ \*\// );
-			expect( result.code ).not.to.match( /^\/\* hublabubla \*\// );
+			expect( result.code ).not.to.match( /.+\/\* hublabubla \*\// );
 		} );
 	} );
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -107,6 +107,21 @@ describe( 'rollup-plugin-babili', () => {
 		} );
 	} );
 
+	it ( 'adds banner as a result of call if plugin banner option is fn itself', () => {
+		return rollup( {
+			entry: 'fixtures/index.js',
+			plugins: [ plugin( {
+				banner: () => {
+					return '/* hublabubla */';
+				}
+			} ) ],
+		} ).then ( ( bundle ) => {
+			const result = bundle.generate();
+
+			expect ( result.code ).to.match( /^\/\* hublabubla \*\// );
+		} );
+	} );
+
 	it( 'preserves comments alongside banner if no comments option is passed', () => {
 		return rollup( {
 			entry: 'fixtures/index.js',

--- a/tests/index.js
+++ b/tests/index.js
@@ -107,22 +107,6 @@ describe( 'rollup-plugin-babili', () => {
 		} );
 	} );
 
-	it( 'prefers banner from own options over one inherited from bundle.generate', () => {
-		return rollup( {
-			entry: 'fixtures/index.js',
-			plugins: [ plugin( {
-				banner: '/* ROLLUP RULEZ */'
-			} ) ],
-		} ).then( ( bundle ) => {
-			const result = bundle.generate( {
-				banner: '/* hublabubla */'
-			} );
-
-			expect( result.code ).to.match( /^\/\* ROLLUP RULEZ \*\// );
-			expect( result.code ).not.to.match( /.+\/\* hublabubla \*\// );
-		} );
-	} );
-
 	it( 'preserves comments alongside banner if no comments option is passed', () => {
 		return rollup( {
 			entry: 'fixtures/index.js',


### PR DESCRIPTION
Closes #14 

Short outcome for this PR:

* Rollup options processing is different for API and config file (my case). For config file it first parses it and then passes same options to `generate` ([here](https://github.com/rollup/rollup/blob/ae54071232bb7236faf0848941c857f7c534ae09/bin/src/runRollup.js#L248) and [here](https://github.com/rollup/rollup/blob/ae54071232bb7236faf0848941c857f7c534ae09/bin/src/runRollup.js#L271))
* transformBundle does not receive all set of options ([source](https://github.com/rollup/rollup/blob/ae54071232bb7236faf0848941c857f7c534ae09/src/utils/transformBundle.js#L11)) which was not fully covered by [this test](https://github.com/Comandeer/rollup-plugin-babili/blob/master/tests/index.js#L96)
* there is no way (as I can see right now) to manipulate  `banner` option of `bundle.generate`

I can squash commits if you'd prefer (unsquashed for now to show some failed tests).

Please comment and thank you for a plugin.